### PR TITLE
fix(deploy): replace pickled request bodies with a safe .npz wire format (RCE)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -55,12 +55,17 @@ The server exposes:
   action chunk;
 - `GET /health` — health check.
 
-Both POST request bodies are Python-pickled dictionaries. FastAPI serializes
+Both POST request bodies are `.npz` bundles (`deploy/wire.py`): numpy arrays
+travel as named entries, all other leaves in a JSON envelope, always decoded
+with `allow_pickle=False`. FastAPI serializes
 responses as JSON: `/act` returns a semantic dictionary and the legacy-named
 `/act_lerobot_bytes` returns a nested numeric list, not raw bytes.
 
-Unpickling is unsafe for untrusted input. The server binds to `127.0.0.1` by
-default; expose it beyond localhost only inside a trusted, isolated network.
+The wire format never unpickles request bodies — pickled payloads are remote
+code execution for anyone who can reach the port. Bodies are also capped
+(`MAX_BODY_BYTES`) so a hostile or broken client cannot exhaust memory. The
+server binds to `127.0.0.1` by default; expose it beyond localhost only inside
+a trusted, isolated network.
 
 For `/act`, send raw task text in `payload["prompt"]`; `encode_payload` applies
 the saved prompt template. Sending already-templated text wraps it twice.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -55,17 +55,23 @@ The server exposes:
   action chunk;
 - `GET /health` — health check.
 
-Both POST request bodies are `.npz` bundles (`deploy/wire.py`): numpy arrays
-travel as named entries, all other leaves in a JSON envelope, always decoded
+Both POST request bodies are `.npz` bundles produced by
+`deploy.wire.pack_payload`: boolean, integer, and floating-point numpy arrays
+travel as named entries and the nested dictionary/list structure travels in a
+tagged JSON envelope. The server validates the archive and always decodes it
 with `allow_pickle=False`. FastAPI serializes
 responses as JSON: `/act` returns a semantic dictionary and the legacy-named
 `/act_lerobot_bytes` returns a nested numeric list, not raw bytes.
 
 The wire format never unpickles request bodies — pickled payloads are remote
-code execution for anyone who can reach the port. Bodies are also capped
-(`MAX_BODY_BYTES`) so a hostile or broken client cannot exhaust memory. The
-server binds to `127.0.0.1` by default; expose it beyond localhost only inside
-a trusted, isolated network.
+code execution for anyone who can reach the port. The server caps the request
+while streaming it and separately caps the archive's total uncompressed size,
+so compressed payloads cannot bypass `MAX_BODY_BYTES`. Existing clients must
+replace `pickle.dumps(payload)` with `pack_payload(payload)`; there is no unsafe
+pickle fallback. The server binds to `127.0.0.1` by default. The safe wire
+format does not provide authentication or encryption, so expose the server
+beyond localhost only inside a trusted, isolated network or behind an
+authenticated TLS proxy.
 
 For `/act`, send raw task text in `payload["prompt"]`; `encode_payload` applies
 the saved prompt template. Sending already-templated text wraps it twice.

--- a/deploy/openloop_with_server.py
+++ b/deploy/openloop_with_server.py
@@ -27,7 +27,6 @@ del _sys, _Path
 import argparse
 import json
 import logging
-import pickle
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Dict
@@ -37,6 +36,7 @@ import numpy as np
 
 from deploy._bootstrap import ensure_configs_registered, resolve_deploy_io
 from deploy.openloop import run_eval
+from deploy.wire import pack_payload
 from tau0_vla.data import action_slices
 from tau0_vla.data.config import discover_config_modules, get_config, list_configs
 
@@ -45,15 +45,16 @@ logger = logging.getLogger(__name__)
 
 class PolicyClient:
     """HTTP client for ``deploy/server.py``'s ``POST /act``. ``infer()``
-    returns the server's raw dict response unchanged. Self-contained
-    (only stdlib) — drop into any end-side script."""
+    returns the server's raw dict response unchanged. Wire encoding lives in
+    ``deploy/wire.py`` (stdlib + numpy) — keep both files together when
+    dropping the client into an end-side script."""
 
     def __init__(self, *, server_url: str, timeout: float = 120.0):
         self._url = server_url.rstrip("/") + "/act"
         self._timeout = timeout
 
     def infer(self, payload: Dict[str, Any]) -> Dict[str, Any]:
-        req = Request(self._url, data=pickle.dumps(payload), method="POST",
+        req = Request(self._url, data=pack_payload(payload), method="POST",
                       headers={"Content-Type": "application/octet-stream"})
         with urlopen(req, timeout=self._timeout) as resp:
             return json.loads(resp.read().decode("utf-8"))

--- a/deploy/server.py
+++ b/deploy/server.py
@@ -9,10 +9,9 @@ del _sys, _Path
 
 import argparse
 import logging
-import pickle
 
 import numpy as np
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, HTTPException, Request
 
 from deploy._bootstrap import (
     discover_checkpoint_config_modules,
@@ -22,6 +21,7 @@ from deploy._bootstrap import (
 )
 from deploy.policy import Tau0VLAPolicy
 from deploy.warmup import _configure_inference_mode, _run_dummy_input_warmup
+from deploy.wire import MAX_BODY_BYTES, unpack_payload
 from tau0_vla.data import action_slices as _action_slices
 
 logger = logging.getLogger(__name__)
@@ -88,9 +88,18 @@ def build_app(policy: Tau0VLAPolicy, *, adapter: str | None = None) -> FastAPI:
 
     app = FastAPI()
 
+    async def _read_payload(request: Request) -> dict:
+        body = await request.body()
+        if len(body) > MAX_BODY_BYTES:
+            raise HTTPException(status_code=413, detail="payload body too large")
+        try:
+            return unpack_payload(body)
+        except Exception as error:
+            raise HTTPException(status_code=400, detail="invalid payload encoding") from error
+
     @app.post("/act_lerobot_bytes")
     async def act(request: Request):
-        actions = policy.infer(adapt(pickle.loads(await request.body())))["actions"]
+        actions = policy.infer(adapt(await _read_payload(request)))["actions"]
         # Unified routes: reorder columns into the SDK's native action layout
         # (arms-then-grippers) before serialising. Component routes: identity.
         arr = deploy_io.apply_sdk_action_perm(actions, resolve_sdk_action_perm())
@@ -103,7 +112,7 @@ def build_app(policy: Tau0VLAPolicy, *, adapter: str | None = None) -> FastAPI:
         is a dict keyed by canonical joint-control component name
         (``arm_joint`` / ``gripper`` / ``waist`` / ...), each value a nested
         list shape ``[chunk, native_dim]``."""
-        payload = pickle.loads(await request.body())
+        payload = await _read_payload(request)
         # A mismatch between the caller's prompt and the templated one is the
         # first thing to check when a policy behaves differently over HTTP than
         # in open loop, so log both. DEBUG, not INFO: this is on the hot path.

--- a/deploy/server.py
+++ b/deploy/server.py
@@ -9,6 +9,7 @@ del _sys, _Path
 
 import argparse
 import logging
+from typing import TYPE_CHECKING
 
 import numpy as np
 from fastapi import FastAPI, HTTPException, Request
@@ -19,12 +20,36 @@ from deploy._bootstrap import (
     ensure_policy_manifest,
     resolve_deploy_io,
 )
-from deploy.policy import Tau0VLAPolicy
-from deploy.warmup import _configure_inference_mode, _run_dummy_input_warmup
-from deploy.wire import MAX_BODY_BYTES, unpack_payload
-from tau0_vla.data import action_slices as _action_slices
+from deploy.wire import MAX_BODY_BYTES, PayloadEncodingError, unpack_payload
+
+if TYPE_CHECKING:
+    from deploy.policy import Tau0VLAPolicy
 
 logger = logging.getLogger(__name__)
+
+
+async def _read_payload(request: Request) -> dict:
+    """Read one bounded request body and decode the safe wire format."""
+    content_length = request.headers.get("content-length")
+    if content_length is not None:
+        try:
+            declared_size = int(content_length)
+        except ValueError as error:
+            raise HTTPException(status_code=400, detail="invalid Content-Length") from error
+        if declared_size < 0:
+            raise HTTPException(status_code=400, detail="invalid Content-Length")
+        if declared_size > MAX_BODY_BYTES:
+            raise HTTPException(status_code=413, detail="payload body too large")
+
+    body = bytearray()
+    async for chunk in request.stream():
+        if len(body) + len(chunk) > MAX_BODY_BYTES:
+            raise HTTPException(status_code=413, detail="payload body too large")
+        body.extend(chunk)
+    try:
+        return unpack_payload(body)
+    except PayloadEncodingError as error:
+        raise HTTPException(status_code=400, detail="invalid payload encoding") from error
 
 
 def _split_action_chunk(action: np.ndarray, slices) -> dict:
@@ -51,6 +76,8 @@ def _require_public_v1_joint_only(data_spec) -> None:
 
 
 def build_app(policy: Tau0VLAPolicy, *, adapter: str | None = None) -> FastAPI:
+    from tau0_vla.data import action_slices as _action_slices
+
     _require_public_v1_joint_only(policy.data_spec)
     # Embodiment-specific wire knowledge (SDK payload keys, camera aliases,
     # state channel map, SDK action column order) lives in layer 3 of an
@@ -88,15 +115,6 @@ def build_app(policy: Tau0VLAPolicy, *, adapter: str | None = None) -> FastAPI:
 
     app = FastAPI()
 
-    async def _read_payload(request: Request) -> dict:
-        body = await request.body()
-        if len(body) > MAX_BODY_BYTES:
-            raise HTTPException(status_code=413, detail="payload body too large")
-        try:
-            return unpack_payload(body)
-        except Exception as error:
-            raise HTTPException(status_code=400, detail="invalid payload encoding") from error
-
     @app.post("/act_lerobot_bytes")
     async def act(request: Request):
         actions = policy.infer(adapt(await _read_payload(request)))["actions"]
@@ -132,6 +150,9 @@ def build_app(policy: Tau0VLAPolicy, *, adapter: str | None = None) -> FastAPI:
 
 
 def main() -> None:
+    from deploy.policy import Tau0VLAPolicy
+    from deploy.warmup import _configure_inference_mode, _run_dummy_input_warmup
+
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("--model", required=True)
     p.add_argument("--route", default=None)

--- a/deploy/wire.py
+++ b/deploy/wire.py
@@ -1,0 +1,75 @@
+"""Safe wire serialization for the inference server.
+
+``/act`` and ``/act_lerobot_bytes`` transport ``{prompt, images, state, meta}``
+payloads. Deserializing a request body with ``pickle.loads`` is unauthenticated
+remote code execution for anyone who can reach the port, so payloads travel as
+``.npz`` loaded with ``allow_pickle=False``: numpy arrays become named entries
+and every other leaf rides in a JSON envelope.
+"""
+from __future__ import annotations
+
+import json
+from io import BytesIO
+from typing import Any, Dict
+
+import numpy as np
+
+# Refuse unbounded request bodies before decoding. Batched camera frames are
+# megabytes, not hundreds of megabytes; anything larger is a broken or hostile
+# client and must not be allocated.
+MAX_BODY_BYTES = 256 * 1024 * 1024
+
+_JSON_ENTRY = "__json__"
+_ARR_PREFIX = "__arr"
+_ND_MARKER = "__nd__"
+
+
+def pack_payload(payload: Dict[str, Any]) -> bytes:
+    """Encode an inference payload as ``.npz`` bytes (no pickle)."""
+    arrays: list[np.ndarray] = []
+
+    def encode(value: Any) -> Any:
+        if isinstance(value, np.ndarray):
+            arrays.append(np.asarray(value))
+            return {_ND_MARKER: len(arrays) - 1}
+        if isinstance(value, np.generic):
+            return value.item()
+        if isinstance(value, dict):
+            return {str(k): encode(v) for k, v in value.items()}
+        if isinstance(value, (list, tuple)):
+            return [encode(v) for v in value]
+        return value
+
+    tree = encode(payload)
+    buf = BytesIO()
+    np.savez(
+        buf,
+        **{_JSON_ENTRY: json.dumps(tree)},
+        **{f"{_ARR_PREFIX}{i}": a for i, a in enumerate(arrays)},
+    )
+    return buf.getvalue()
+
+
+def unpack_payload(data: bytes) -> Dict[str, Any]:
+    """Decode a ``pack_payload`` body. Never unpickles anything."""
+    if len(data) > MAX_BODY_BYTES:
+        raise ValueError(
+            f"payload body {len(data)} bytes exceeds {MAX_BODY_BYTES} limit"
+        )
+    with np.load(BytesIO(data), allow_pickle=False) as npz:
+        tree = json.loads(str(npz[_JSON_ENTRY]))
+        arrays = [
+            npz[f"{_ARR_PREFIX}{i}"]
+            for i in range(sum(1 for k in npz.files if k.startswith(_ARR_PREFIX)))
+        ]
+
+    def decode(node: Any) -> Any:
+        if isinstance(node, dict):
+            if set(node) == {_ND_MARKER}:
+                return arrays[node[_ND_MARKER]]
+            return {k: decode(v) for k, v in node.items()}
+        if isinstance(node, list):
+            return [decode(v) for v in node]
+        return node
+
+    return decode(tree)

--- a/deploy/wire.py
+++ b/deploy/wire.py
@@ -1,75 +1,209 @@
 """Safe wire serialization for the inference server.
 
-``/act`` and ``/act_lerobot_bytes`` transport ``{prompt, images, state, meta}``
-payloads. Deserializing a request body with ``pickle.loads`` is unauthenticated
-remote code execution for anyone who can reach the port, so payloads travel as
-``.npz`` loaded with ``allow_pickle=False``: numpy arrays become named entries
-and every other leaf rides in a JSON envelope.
+``/act`` and ``/act_lerobot_bytes`` transport nested inference payloads.
+Deserializing a request body with ``pickle.loads`` is unauthenticated remote
+code execution, so payloads travel as a small, strictly validated ``.npz``
+archive. NumPy arrays are archive entries and the container structure is a
+tagged JSON tree; neither side ever enables NumPy object deserialization.
 """
+
 from __future__ import annotations
 
 import json
+import zipfile
 from io import BytesIO
 from typing import Any, Dict
 
 import numpy as np
 
-# Refuse unbounded request bodies before decoding. Batched camera frames are
-# megabytes, not hundreds of megabytes; anything larger is a broken or hostile
-# client and must not be allocated.
+# The server enforces MAX_BODY_BYTES while streaming the request. The decoder
+# repeats that check for non-HTTP callers and separately limits the sum of the
+# archive entries' uncompressed sizes to prevent compressed zip bombs.
 MAX_BODY_BYTES = 256 * 1024 * 1024
+MAX_DECODED_BYTES = MAX_BODY_BYTES
 
 _JSON_ENTRY = "__json__"
 _ARR_PREFIX = "__arr"
-_ND_MARKER = "__nd__"
+_MAX_ARRAYS = 1024
+_ALLOWED_ARRAY_KINDS = frozenset("biuf")
+_ALLOWED_COMPRESSION = frozenset((zipfile.ZIP_STORED, zipfile.ZIP_DEFLATED))
+
+
+class PayloadEncodingError(ValueError):
+    """The request body is not a valid safe-wire payload."""
+
+
+def _validate_array(array: np.ndarray) -> None:
+    if array.dtype.hasobject or array.dtype.kind not in _ALLOWED_ARRAY_KINDS:
+        raise TypeError(
+            f"wire arrays must have a bool, integer, unsigned-integer, or floating dtype; got {array.dtype}"
+        )
 
 
 def pack_payload(payload: Dict[str, Any]) -> bytes:
-    """Encode an inference payload as ``.npz`` bytes (no pickle)."""
+    """Encode an inference payload as ``.npz`` bytes without pickle."""
+    if not isinstance(payload, dict):
+        raise TypeError(f"payload root must be a dict, got {type(payload).__name__}")
+
     arrays: list[np.ndarray] = []
 
     def encode(value: Any) -> Any:
         if isinstance(value, np.ndarray):
-            arrays.append(np.asarray(value))
-            return {_ND_MARKER: len(arrays) - 1}
+            array = np.asarray(value)
+            _validate_array(array)
+            if len(arrays) >= _MAX_ARRAYS:
+                raise ValueError(f"payload contains more than {_MAX_ARRAYS} arrays")
+            arrays.append(array)
+            return ["ndarray", len(arrays) - 1]
         if isinstance(value, np.generic):
-            return value.item()
+            return encode(value.item())
         if isinstance(value, dict):
-            return {str(k): encode(v) for k, v in value.items()}
-        if isinstance(value, (list, tuple)):
-            return [encode(v) for v in value]
-        return value
+            items = []
+            for key, item in value.items():
+                if not isinstance(key, str):
+                    raise TypeError(f"wire dictionary keys must be strings, got {type(key).__name__}")
+                items.append([key, encode(item)])
+            return ["dict", items]
+        if isinstance(value, list):
+            return ["list", [encode(item) for item in value]]
+        if isinstance(value, tuple):
+            return ["tuple", [encode(item) for item in value]]
+        if value is None or isinstance(value, (bool, int, float, str)):
+            return ["scalar", value]
+        raise TypeError(f"unsupported wire value type: {type(value).__name__}")
 
     tree = encode(payload)
+    try:
+        envelope = json.dumps(tree, allow_nan=False, separators=(",", ":"), ensure_ascii=False)
+    except (TypeError, ValueError) as error:
+        raise TypeError(f"payload contains a non-JSON scalar: {error}") from error
+
     buf = BytesIO()
     np.savez(
         buf,
-        **{_JSON_ENTRY: json.dumps(tree)},
-        **{f"{_ARR_PREFIX}{i}": a for i, a in enumerate(arrays)},
+        **{_JSON_ENTRY: envelope},
+        **{f"{_ARR_PREFIX}{index}": array for index, array in enumerate(arrays)},
     )
-    return buf.getvalue()
+    data = buf.getvalue()
+    if len(data) > MAX_BODY_BYTES:
+        raise ValueError(f"encoded payload is {len(data)} bytes; limit is {MAX_BODY_BYTES}")
+    return data
+
+
+def _archive_array_indices(archive: zipfile.ZipFile) -> list[int]:
+    infos = archive.infolist()
+    if len(infos) > _MAX_ARRAYS + 1:
+        raise PayloadEncodingError("archive contains too many entries")
+
+    names = [info.filename for info in infos]
+    if len(names) != len(set(names)):
+        raise PayloadEncodingError("archive contains duplicate entries")
+    if f"{_JSON_ENTRY}.npy" not in names:
+        raise PayloadEncodingError("archive is missing its JSON envelope")
+
+    decoded_size = 0
+    indices = []
+    for info in infos:
+        if info.is_dir() or info.flag_bits & 0x1:
+            raise PayloadEncodingError("archive directories and encryption are not supported")
+        if info.compress_type not in _ALLOWED_COMPRESSION:
+            raise PayloadEncodingError("archive uses an unsupported compression method")
+        decoded_size += info.file_size
+        if decoded_size > MAX_DECODED_BYTES:
+            raise PayloadEncodingError(f"decoded payload exceeds the {MAX_DECODED_BYTES}-byte limit")
+
+        if info.filename == f"{_JSON_ENTRY}.npy":
+            continue
+        prefix = f"{_ARR_PREFIX}"
+        suffix = ".npy"
+        if not info.filename.startswith(prefix) or not info.filename.endswith(suffix):
+            raise PayloadEncodingError(f"unexpected archive entry: {info.filename!r}")
+        index_text = info.filename[len(prefix) : -len(suffix)]
+        if not index_text.isascii() or not index_text.isdecimal():
+            raise PayloadEncodingError(f"invalid array entry: {info.filename!r}")
+        indices.append(int(index_text))
+
+    indices.sort()
+    if indices != list(range(len(indices))):
+        raise PayloadEncodingError("array entries must be numbered contiguously from zero")
+    return indices
+
+
+def _decode_tree(tree: Any, arrays: list[np.ndarray]) -> Dict[str, Any]:
+    used_arrays: list[int] = []
+
+    def decode(node: Any) -> Any:
+        if not isinstance(node, list) or len(node) != 2 or not isinstance(node[0], str):
+            raise PayloadEncodingError("invalid JSON node")
+        tag, value = node
+        if tag == "ndarray":
+            if isinstance(value, bool) or not isinstance(value, int) or not 0 <= value < len(arrays):
+                raise PayloadEncodingError("invalid ndarray reference")
+            used_arrays.append(value)
+            return arrays[value]
+        if tag in ("list", "tuple"):
+            if not isinstance(value, list):
+                raise PayloadEncodingError(f"invalid {tag} node")
+            items = [decode(item) for item in value]
+            return items if tag == "list" else tuple(items)
+        if tag == "dict":
+            if not isinstance(value, list):
+                raise PayloadEncodingError("invalid dict node")
+            result = {}
+            for pair in value:
+                if not isinstance(pair, list) or len(pair) != 2 or not isinstance(pair[0], str):
+                    raise PayloadEncodingError("invalid dictionary item")
+                key, item = pair
+                if key in result:
+                    raise PayloadEncodingError(f"duplicate dictionary key: {key!r}")
+                result[key] = decode(item)
+            return result
+        if tag == "scalar":
+            if value is not None and not isinstance(value, (bool, int, float, str)):
+                raise PayloadEncodingError("invalid scalar node")
+            return value
+        raise PayloadEncodingError(f"unknown JSON node tag: {tag!r}")
+
+    result = decode(tree)
+    if not isinstance(result, dict):
+        raise PayloadEncodingError("payload root must be a dict")
+    if sorted(used_arrays) != list(range(len(arrays))):
+        raise PayloadEncodingError("each archive array must be referenced exactly once")
+    return result
 
 
 def unpack_payload(data: bytes) -> Dict[str, Any]:
     """Decode a ``pack_payload`` body. Never unpickles anything."""
     if len(data) > MAX_BODY_BYTES:
-        raise ValueError(
-            f"payload body {len(data)} bytes exceeds {MAX_BODY_BYTES} limit"
-        )
-    with np.load(BytesIO(data), allow_pickle=False) as npz:
-        tree = json.loads(str(npz[_JSON_ENTRY]))
-        arrays = [
-            npz[f"{_ARR_PREFIX}{i}"]
-            for i in range(sum(1 for k in npz.files if k.startswith(_ARR_PREFIX)))
-        ]
+        raise PayloadEncodingError(f"payload body {len(data)} bytes exceeds {MAX_BODY_BYTES} limit")
 
-    def decode(node: Any) -> Any:
-        if isinstance(node, dict):
-            if set(node) == {_ND_MARKER}:
-                return arrays[node[_ND_MARKER]]
-            return {k: decode(v) for k, v in node.items()}
-        if isinstance(node, list):
-            return [decode(v) for v in node]
-        return node
+    try:
+        source = BytesIO(data)
+        with zipfile.ZipFile(source) as archive:
+            indices = _archive_array_indices(archive)
 
-    return decode(tree)
+        source.seek(0)
+        with np.load(source, allow_pickle=False) as npz:
+            expected_entries = [_JSON_ENTRY, *(f"{_ARR_PREFIX}{index}" for index in indices)]
+            if sorted(npz.files) != sorted(expected_entries):
+                raise PayloadEncodingError("archive entry names do not match the wire schema")
+
+            envelope = npz[_JSON_ENTRY]
+            if envelope.shape != () or envelope.dtype.kind not in ("U", "S"):
+                raise PayloadEncodingError("JSON envelope must be a scalar string")
+            tree = json.loads(envelope.item())
+
+            arrays = []
+            decoded_array_bytes = 0
+            for index in indices:
+                array = np.asarray(npz[f"{_ARR_PREFIX}{index}"])
+                _validate_array(array)
+                decoded_array_bytes += array.nbytes
+                if decoded_array_bytes > MAX_DECODED_BYTES:
+                    raise PayloadEncodingError("decoded arrays exceed the size limit")
+                arrays.append(array)
+        return _decode_tree(tree, arrays)
+    except PayloadEncodingError:
+        raise
+    except Exception as error:
+        raise PayloadEncodingError("invalid payload encoding") from error

--- a/src/tau0_vla/adapters/g1/deploy_io.py
+++ b/src/tau0_vla/adapters/g1/deploy_io.py
@@ -7,7 +7,7 @@ one — what column order the SDK expects actions back in.
 
 Extracted verbatim out of ``deploy/server.py`` per
 the adapter's layer-3 boundary. ``deploy/server.py``
-keeps the HTTP surface (routes, pickle framing, logging); this module keeps the
+keeps the HTTP surface (routes, wire framing, logging); this module keeps the
 embodiment knowledge. No behaviour changed in the move.
 
 For your own robot, copy this file. Four things in it are yours to change, and

--- a/tests/test_deploy_wire.py
+++ b/tests/test_deploy_wire.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import io
+import json
+import pickle
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import numpy as np
+from fastapi import HTTPException
+
+from deploy.server import _read_payload
+from deploy.wire import PayloadEncodingError, pack_payload, unpack_payload
+
+
+class _WriteOnUnpickle:
+    def __init__(self, path: Path):
+        self.path = path
+
+    def __reduce__(self):
+        return Path.write_text, (self.path, "pickle executed")
+
+
+class _Request:
+    def __init__(self, chunks, *, content_length=None):
+        self.headers = {}
+        if content_length is not None:
+            self.headers["content-length"] = str(content_length)
+        self._chunks = chunks
+        self.chunks_read = 0
+
+    async def stream(self):
+        for chunk in self._chunks:
+            self.chunks_read += 1
+            yield chunk
+
+
+class WireFormatTest(unittest.TestCase):
+    def test_round_trip_nested_payload(self):
+        payload = {
+            "prompt": "pick up the blue cup",
+            "images": {
+                "front": np.arange(3 * 4 * 3, dtype=np.uint8).reshape(3, 4, 3),
+                "wrist": np.zeros((2, 2, 3), dtype=np.uint8),
+            },
+            "state": np.array([1.5, -2.0], dtype=np.float32),
+            "meta": {
+                "episode": np.int64(7),
+                "confidence": np.float32(0.5),
+                "flags": [True, None, "ready"],
+                "tuple": (1, 2),
+            },
+        }
+
+        decoded = unpack_payload(pack_payload(payload))
+
+        self.assertEqual(decoded["prompt"], payload["prompt"])
+        np.testing.assert_array_equal(decoded["images"]["front"], payload["images"]["front"])
+        np.testing.assert_array_equal(decoded["images"]["wrist"], payload["images"]["wrist"])
+        np.testing.assert_array_equal(decoded["state"], payload["state"])
+        self.assertEqual(decoded["state"].dtype, np.dtype(np.float32))
+        self.assertEqual(
+            decoded["meta"],
+            {"episode": 7, "confidence": 0.5, "flags": [True, None, "ready"], "tuple": (1, 2)},
+        )
+
+    def test_marker_shaped_user_dictionary_round_trips(self):
+        payload = {"meta": {"__nd__": 0}, "array": np.array([9], dtype=np.int16)}
+        decoded = unpack_payload(pack_payload(payload))
+        self.assertEqual(decoded["meta"], {"__nd__": 0})
+        np.testing.assert_array_equal(decoded["array"], payload["array"])
+
+    def test_rejects_unsafe_or_ambiguous_client_values(self):
+        with self.assertRaises(TypeError):
+            pack_payload({"array": np.array([object()], dtype=object)})
+        with self.assertRaises(TypeError):
+            pack_payload({1: "non-string key"})
+        with self.assertRaises(TypeError):
+            pack_payload({"complex": np.array([1j], dtype=np.complex64)})
+
+    def test_rejects_pickle_and_garbage(self):
+        for body in (pickle.dumps({"prompt": "unsafe"}), b"not an npz archive"):
+            with self.subTest(body=body[:10]):
+                with self.assertRaises(PayloadEncodingError):
+                    unpack_payload(body)
+
+    def test_rejecting_pickle_does_not_execute_reduce(self):
+        with tempfile.TemporaryDirectory() as directory:
+            marker = Path(directory) / "executed"
+            body = pickle.dumps(_WriteOnUnpickle(marker))
+            with self.assertRaises(PayloadEncodingError):
+                unpack_payload(body)
+            self.assertFalse(marker.exists())
+
+    def test_rejects_body_over_wire_limit(self):
+        with mock.patch("deploy.wire.MAX_BODY_BYTES", 8):
+            with self.assertRaisesRegex(PayloadEncodingError, "payload body"):
+                unpack_payload(b"123456789")
+
+    def test_rejects_unexpected_archive_entry(self):
+        buf = io.BytesIO()
+        np.savez(buf, __json__=json.dumps(["dict", []]), unexpected=np.array([1]))
+        with self.assertRaisesRegex(PayloadEncodingError, "unexpected archive entry"):
+            unpack_payload(buf.getvalue())
+
+    def test_rejects_non_contiguous_array_entries(self):
+        buf = io.BytesIO()
+        tree = ["dict", [["array", ["ndarray", 1]]]]
+        np.savez(buf, __json__=json.dumps(tree), __arr1=np.array([1], dtype=np.int8))
+        with self.assertRaisesRegex(PayloadEncodingError, "numbered contiguously"):
+            unpack_payload(buf.getvalue())
+
+    def test_rejects_compressed_archive_over_decoded_limit(self):
+        buf = io.BytesIO()
+        tree = ["dict", [["array", ["ndarray", 0]]]]
+        np.savez_compressed(buf, __json__=json.dumps(tree), __arr0=np.zeros(4096, dtype=np.uint8))
+        self.assertLess(len(buf.getvalue()), 1024)
+        with mock.patch("deploy.wire.MAX_DECODED_BYTES", 1024):
+            with self.assertRaisesRegex(PayloadEncodingError, "decoded payload exceeds"):
+                unpack_payload(buf.getvalue())
+
+
+class RequestLimitTest(unittest.IsolatedAsyncioTestCase):
+    async def test_valid_chunked_request(self):
+        body = pack_payload({"state": np.array([1.0], dtype=np.float32)})
+        request = _Request([body[:17], body[17:]], content_length=len(body))
+        decoded = await _read_payload(request)
+        np.testing.assert_array_equal(decoded["state"], np.array([1.0], dtype=np.float32))
+
+    async def test_content_length_rejected_before_streaming(self):
+        request = _Request([b"must not be read"], content_length=9)
+        with mock.patch("deploy.server.MAX_BODY_BYTES", 8):
+            with self.assertRaises(HTTPException) as caught:
+                await _read_payload(request)
+        self.assertEqual(caught.exception.status_code, 413)
+        self.assertEqual(request.chunks_read, 0)
+
+    async def test_chunked_body_stops_at_limit(self):
+        request = _Request([b"1234", b"56789", b"must not be read"])
+        with mock.patch("deploy.server.MAX_BODY_BYTES", 8):
+            with self.assertRaises(HTTPException) as caught:
+                await _read_payload(request)
+        self.assertEqual(caught.exception.status_code, 413)
+        self.assertEqual(request.chunks_read, 2)
+
+    async def test_invalid_content_length_and_encoding_return_400(self):
+        request = _Request([b"garbage"], content_length="invalid")
+        with self.assertRaises(HTTPException) as caught:
+            await _read_payload(request)
+        self.assertEqual(caught.exception.status_code, 400)
+
+        request = _Request([b"garbage"])
+        with self.assertRaises(HTTPException) as caught:
+            await _read_payload(request)
+        self.assertEqual(caught.exception.status_code, 400)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Both inference endpoints deserialize the request body with `pickle.loads`:

- `POST /act` and `POST /act_lerobot_bytes` in `deploy/server.py` each call `pickle.loads(await request.body())`.

Pickle is not a data format — it is a bytecode interpreter. **Anyone who can reach the port gets remote code execution as the serving process** (which typically holds a loaded GPU model and runs with broad host access). The server documents `--host 0.0.0.0` for LAN serving, and even on the default `127.0.0.1` any unprivileged local process can drive the endpoint.

This PR replaces the wire format, mirroring the fix pattern used by other VLA serving stacks:

- **`deploy/wire.py` (new):** payloads travel as `.npz` decoded with `allow_pickle=False`. Boolean, integer, and floating-point numpy arrays are named entries; the remaining nested structure is stored in an unambiguous tagged JSON envelope. Archive entries, dtypes, references, and total uncompressed size are validated before use.
- **`deploy/server.py`:** both endpoints decode via `unpack_payload`. Requests are read incrementally and rejected with HTTP 413 once the 256 MiB limit is exceeded; invalid payloads get HTTP 400. The archive's total uncompressed size is checked before NumPy loads any entries, preventing compressed payloads from bypassing the limit.
- **`deploy/openloop_with_server.py`:** the open-loop client packs with the same module; the client now pairs with `deploy/wire.py`.
- **`deploy/README.md` / G1 adapter comment:** wire-contract documentation is updated.

## Impact if unsolved

A robot inference server is a high-value foothold: code execution there controls what the robot does next, not just data. With `--host 0.0.0.0`, one network peer posting a crafted body owns the box.

## Compatibility note

`/act_lerobot_bytes` is named for an external embodiment SDK that currently posts pickled bytes — that client must switch to `pack_payload` from `deploy/wire.py` (stdlib + numpy). The endpoint contract (routes, response shapes) is unchanged. There is intentionally no unsafe pickle fallback.

## Test plan

- Added 13 unit tests covering realistic payload round-trips, malicious pickle rejection without code execution, streaming body limits, compressed archive bombs, malformed archives, marker collisions, unsupported dtypes, and HTTP 400/413 behavior.
- Tests pass with NumPy 2.2.6 and FastAPI 0.101.0.
- Python compilation, Ruff lint, focused Ruff formatting checks, and `git diff --check` pass.
- A temporary merge with the latest `main` is conflict-free and passes the same tests.

Maintainer hardening and tests were added in `7b1ed13` while preserving the original contributor commit and authorship.

Made with [Cursor](https://cursor.com)
