### PR TITLE
fix(trainer): bind the debugpy hook to localhost by default (unauthenticated RCE surface)

### DIFF
--- a/src/tau0_vla/trainer/train.py
+++ b/src/tau0_vla/trainer/train.py
@@ -538,7 +538,9 @@ def _maybe_wait_for_debugger() -> None:
     matching torchrun rank(s) listen on port ``VLA_DEBUGPY_PORT``(default
     5678)+rank and BLOCK until a debugger (VSCode "attach") connects. Unset =
     zero overhead. Non-listed ranks run free; while a listed rank sits at a
-    breakpoint the others wait at the next collective (ddp_timeout budget)."""
+    breakpoint the others wait at the next collective (ddp_timeout budget).
+    Listens on ``VLA_DEBUGPY_HOST`` (default ``127.0.0.1``); set it only when
+    remote attach is genuinely required, since debugpy has no authentication."""
     ranks = os.environ.get("VLA_DEBUGPY_RANKS")
     if not ranks:
         return
@@ -548,8 +550,13 @@ def _maybe_wait_for_debugger() -> None:
     import debugpy
 
     port = int(os.environ.get("VLA_DEBUGPY_PORT", "5678")) + rank
-    debugpy.listen(("0.0.0.0", port))
-    print(f"[debugpy] rank {rank} listening on :{port} — waiting for attach ...", flush=True)
+    # debugpy has no authentication: whoever connects first executes arbitrary
+    # code in the training process. Default to localhost so enabling the
+    # debugger on a shared cluster does not expose RCE to every network peer;
+    # VLA_DEBUGPY_HOST is the explicit escape hatch for remote attach.
+    host = os.environ.get("VLA_DEBUGPY_HOST", "127.0.0.1")
+    debugpy.listen((host, port))
+    print(f"[debugpy] rank {rank} listening on {host}:{port} — waiting for attach ...", flush=True)
     debugpy.wait_for_client()
 
 

--- a/src/tau0_vla/trainer/train.py
+++ b/src/tau0_vla/trainer/train.py
@@ -554,7 +554,7 @@ def _maybe_wait_for_debugger() -> None:
     # code in the training process. Default to localhost so enabling the
     # debugger on a shared cluster does not expose RCE to every network peer;
     # VLA_DEBUGPY_HOST is the explicit escape hatch for remote attach.
-    host = os.environ.get("VLA_DEBUGPY_HOST", "127.0.0.1")
+    host = os.environ.get("VLA_DEBUGPY_HOST") or "127.0.0.1"
     debugpy.listen((host, port))
     print(f"[debugpy] rank {rank} listening on {host}:{port} — waiting for attach ...", flush=True)
     debugpy.wait_for_client()

--- a/tests/test_debugpy_hook.py
+++ b/tests/test_debugpy_hook.py
@@ -1,0 +1,65 @@
+"""Regression tests for the opt-in debugpy listener."""
+
+import os
+import sys
+import types
+import unittest
+from unittest import mock
+
+# ``transformers`` is only used inside ``train()``. Keep this focused unit test
+# importable in lightweight environments where the full training stack is not
+# installed.
+sys.modules.setdefault("transformers", types.ModuleType("transformers"))
+logging_stub = types.ModuleType("tau0_vla.utils.logging")
+logging_stub.setup_py_logging = mock.Mock()
+sys.modules.setdefault("tau0_vla.utils.logging", logging_stub)
+
+from tau0_vla.trainer.train import _maybe_wait_for_debugger
+
+
+class DebugpyHookTest(unittest.TestCase):
+    def run_hook(self, **environment: str):
+        debugpy = types.ModuleType("debugpy")
+        debugpy.listen = mock.Mock()
+        debugpy.wait_for_client = mock.Mock()
+
+        with (
+            mock.patch.dict(os.environ, environment, clear=True),
+            mock.patch.dict(sys.modules, {"debugpy": debugpy}),
+        ):
+            _maybe_wait_for_debugger()
+
+        return debugpy
+
+    def test_defaults_to_loopback_and_waits_for_selected_rank(self):
+        debugpy = self.run_hook(VLA_DEBUGPY_RANKS="0")
+
+        debugpy.listen.assert_called_once_with(("127.0.0.1", 5678))
+        debugpy.wait_for_client.assert_called_once_with()
+
+    def test_empty_host_also_defaults_to_loopback(self):
+        debugpy = self.run_hook(VLA_DEBUGPY_RANKS="0", VLA_DEBUGPY_HOST="")
+
+        debugpy.listen.assert_called_once_with(("127.0.0.1", 5678))
+        debugpy.wait_for_client.assert_called_once_with()
+
+    def test_explicit_host_and_rank_offset_are_honored(self):
+        debugpy = self.run_hook(
+            VLA_DEBUGPY_RANKS="0, 2",
+            VLA_DEBUGPY_HOST="192.0.2.10",
+            VLA_DEBUGPY_PORT="6000",
+            RANK="2",
+        )
+
+        debugpy.listen.assert_called_once_with(("192.0.2.10", 6002))
+        debugpy.wait_for_client.assert_called_once_with()
+
+    def test_unselected_rank_does_not_listen_or_wait(self):
+        debugpy = self.run_hook(VLA_DEBUGPY_RANKS="0,2", RANK="1")
+
+        debugpy.listen.assert_not_called()
+        debugpy.wait_for_client.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Bind the env-gated debugpy hook to `127.0.0.1` by default.
- Keep `VLA_DEBUGPY_HOST` as an explicit remote-debugging escape hatch; unset and empty values both fall back to loopback.
- Add behavior-level regression tests for the default and explicit hosts, rank-based port offsets, and unselected ranks.

## Security impact

debugpy has no authentication: the first client to attach can execute arbitrary code in the training process. Defaulting to loopback prevents enabling this debugging convenience from exposing the listener to every network peer on a shared cluster.

## Maintainer validation

Validated locally against the latest `main` after #5:

- `PYTHONPATH=/tmp/tau0-pr6-testdeps:src python -m unittest discover -s tests -v` — 17 passed
- `python -m py_compile src/tau0_vla/trainer/train.py tests/test_debugpy_hook.py tests/test_deploy_wire.py` — passed
- `ruff check src/tau0_vla/trainer/train.py tests/test_debugpy_hook.py tests/test_deploy_wire.py` — passed

The debugpy module and `wait_for_client()` are mocked in the new tests, so the test suite never opens a socket or blocks.

Original contribution made with [Cursor](https://cursor.com).